### PR TITLE
Reimplemenation of events

### DIFF
--- a/LISA/examples/earth/earth.py
+++ b/LISA/examples/earth/earth.py
@@ -114,8 +114,8 @@ class Earth(o.Base):
     def createWidget(self):
         self._widget = Application(layout="vertical")
         self._widget.title.text = "Earth mover"
-        self._widget.x = 300
-        self._widget.y = 300
+        self._widget.x = 0
+        self._widget.y = 0
 
         # create vertical layout for buttons
         hlayout = HorizontalLayout()

--- a/LISA/examples/earth_lighting/earth_lighting.py
+++ b/LISA/examples/earth_lighting/earth_lighting.py
@@ -153,8 +153,8 @@ class Earth(o.Base):
     def createWidget(self):
         self._widget = Application(layout="vertical")
         self._widget.title.text = "Earth mover"
-        self._widget.x = 300
-        self._widget.y = 300
+        self._widget.x = 0
+        self._widget.y = 0
 
         # create the slider
         self.rotation_text = Text()

--- a/LISA/examples/heightmap/heightmap.py
+++ b/LISA/examples/heightmap/heightmap.py
@@ -48,8 +48,8 @@ class HeightMap(o.Base):
     def createWidget(self):
         self._widget = Application(layout="vertical")
         self._widget.title.text = "Sphere mesh"
-        self._widget.x = 300
-        self._widget.y = 300
+        self._widget.x = 0
+        self._widget.y = 0
 
         # create a slider for attenuation
         self.attenuation_text = Text()

--- a/LISA/examples/rippler/rippler.py
+++ b/LISA/examples/rippler/rippler.py
@@ -81,8 +81,8 @@ class Rippler(o.Base):
     def createWidget(self):
         self._widget = Application(layout="horizontal")
         self._widget.title.text = "Window title"
-        self._widget.x = 300
-        self._widget.y = 300
+        self._widget.x = 0
+        self._widget.y = 0
 
         # create vertical layout for buttons
         vlayout = VerticalLayout()

--- a/LISA/examples/sphere_refinement/sphere_refinement.py
+++ b/LISA/examples/sphere_refinement/sphere_refinement.py
@@ -92,8 +92,8 @@ class SphereRefinement(o.Base):
     def createWidget(self):
         self._widget = Application(layout="vertical")
         self._widget.title.text = "Sphere mesh"
-        self._widget.x = 300
-        self._widget.y = 300
+        self._widget.x = 0
+        self._widget.y = 0
 
         # create a slider for attenuation
         self.attenuation_text = Text()

--- a/LISA/gui/sdl2/OGLWidget.py
+++ b/LISA/gui/sdl2/OGLWidget.py
@@ -140,7 +140,10 @@ class OGLWidget(SDLWindow):
                 "displayed on the window!"
             )
 
-    def resizeGL(self, w, h):
+    def resizeEvent(self, event):
+        if super(OGLWidget, self).resizeEvent(event):
+            return
+        w, h = event.windowSize
         h = 1 if h == 0 else h
         GL.glViewport(0, 0, w, h)
         self.projection.ratio = w / h

--- a/LISA/gui/sdl2/__init__.py
+++ b/LISA/gui/sdl2/__init__.py
@@ -2,5 +2,4 @@
 # -*- coding: utf-8 -*-
 
 
-
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/__init__.py
+++ b/LISA/gui/sdl2/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from .hook import *
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/__init__.py
+++ b/LISA/gui/sdl2/event_types/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pkgutil
+from .event_types import EventType
+
+__all__ = ["EventType"]
+
+# allow automatic loading of modules recursively (automatic registration of
+# plugins and viewers)
+__path__ = pkgutil.extend_path(__path__, __name__)
+for importer, modname, ispkg in pkgutil.walk_packages(
+    path=__path__,
+    prefix=__name__ + '.'
+):
+    __import__(modname)
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/event_types.py
+++ b/LISA/gui/sdl2/event_types/event_types.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import abc
+
+__all__ = ["EventType", "eventor"]
+
+
+def eventor(func):
+    """
+    A decorator to indicate which method needs to be called after an event
+    occurred. This allow to not process all the tree if no corresponding event
+    happened.
+    """
+    def decorator(self, event):
+        func(self, event)
+        self.methods[self.__event_method__][0] = True
+    return decorator
+
+
+class EventTypeMetaclass(abc.ABCMeta):
+    """
+    Metaclass to register available kinds of event type and easily access them
+    without adding a lot of if statement in the code for each kind of event.
+    """
+
+    def __init__(cls, name, bases, attrs):
+        # create the class as usual
+        super(EventTypeMetaclass, cls).__init__(name, bases, attrs)
+
+        # store the available classes
+        if not hasattr(cls, "available_events"):
+            cls.available_events = {}
+        else:
+            if not hasattr(cls, "__register_type__"):
+                raise AttributeError(
+                    "An event type needs attribute __register_type__"
+                )
+            cls.available_events[cls.__register_type__] = cls
+
+        # mapping for instantiated events
+        if not hasattr(cls, "events"):
+            cls.events = {}
+
+    def __call__(cls, *args, **kwargs):
+        """
+        Called when a class is instantiated.
+        """
+        # register the instance if not already created (events are singleton)
+        if cls.__register_type__ in cls.events:
+            return cls.events[cls.__register_type__]
+
+        # create the instance
+        instance = super(EventTypeMetaclass, cls).__call__(*args, **kwargs)
+
+        # store it to retrieve it later
+        cls.events[instance.__register_type__] = instance
+
+        return instance
+
+
+class EventType(object, metaclass=EventTypeMetaclass):
+    """
+    A base class for the kind of SDL events to manage in the window.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        At the initialization, the keywords arguments are processed to be set
+        as attributes of the event type, allowing to access some variables
+        inside the event processing.
+        """
+        # check that no arguments are given
+        if len(args):
+            raise ValueError("Event type is initialized only with keywords")
+
+        # for each keyword argument, store an attribute
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    @eventor
+    @abc.abstractmethod
+    def processEvent(self, event):
+        """
+        A method called to process the event.
+        """
+        pass
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/key_down_event.py
+++ b/LISA/gui/sdl2/event_types/key_down_event.py
@@ -12,12 +12,14 @@ class KeyDownEvent(EventType):
     """
     To manage key down event.
     """
-    __register_type__ = sdl2.SDL_KEYDOWN
-    __event_method__ = "keyEvent"
+    class Meta:
+        register_type = sdl2.SDL_KEYDOWN
+        event_method = "keyEvent"
+        event_attribute = "keys"
 
     def processEvent(self, event):
-        super(KeyDownEvent, self).processEvent(event)
         self.keys[event.key.keysym.scancode] = True
+        super(KeyDownEvent, self).processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/key_down_event.py
+++ b/LISA/gui/sdl2/event_types/key_down_event.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+
+from .event_types import EventType
+
+__all__ = ["KeyDownEvent"]
+
+
+class KeyDownEvent(EventType):
+    """
+    To manage key down event.
+    """
+    __register_type__ = sdl2.SDL_KEYDOWN
+    __event_method__ = "keyEvent"
+
+    def processEvent(self, event):
+        super(KeyDownEvent, self).processEvent(event)
+        self.keys[event.key.keysym.scancode] = True
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/key_up_event.py
+++ b/LISA/gui/sdl2/event_types/key_up_event.py
@@ -12,12 +12,14 @@ class KeyUpEvent(EventType):
     """
     To manage key up event.
     """
-    __register_type__ = sdl2.SDL_KEYUP
-    __event_method__ = "keyEvent"
+    class Meta:
+        register_type = sdl2.SDL_KEYUP
+        event_method = "keyEvent"
+        event_attribute = "keys"
 
     def processEvent(self, event):
-        super(KeyUpEvent, self).processEvent(event)
         self.keys[event.key.keysym.scancode] = False
+        super(KeyUpEvent, self).processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/key_up_event.py
+++ b/LISA/gui/sdl2/event_types/key_up_event.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+
+from .event_types import EventType
+
+__all__ = ["KeyUpEvent"]
+
+
+class KeyUpEvent(EventType):
+    """
+    To manage key up event.
+    """
+    __register_type__ = sdl2.SDL_KEYUP
+    __event_method__ = "keyEvent"
+
+    def processEvent(self, event):
+        super(KeyUpEvent, self).processEvent(event)
+        self.keys[event.key.keysym.scancode] = False
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_button_down_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_button_down_event.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+
+from .event_types import EventType
+
+__all__ = ["MouseButtonDownEvent"]
+
+
+class MouseButtonDownEvent(EventType):
+    """
+    To manage mouse up event.
+    """
+    __register_type__ = sdl2.SDL_MOUSEBUTTONDOWN
+    __event_method__ = "mouseEvent"
+
+    def processEvent(self, event):
+        super(MouseButtonDownEvent, self).processEvent(event)
+        self.mouse[event.button.button] = True
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_button_down_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_button_down_event.py
@@ -12,12 +12,14 @@ class MouseButtonDownEvent(EventType):
     """
     To manage mouse up event.
     """
-    __register_type__ = sdl2.SDL_MOUSEBUTTONDOWN
-    __event_method__ = "mouseEvent"
+    class Meta:
+        register_type = sdl2.SDL_MOUSEBUTTONDOWN
+        event_method = "mouseEvent"
+        event_attribute = "mouse"
 
     def processEvent(self, event):
-        super(MouseButtonDownEvent, self).processEvent(event)
         self.mouse[event.button.button] = True
+        super(MouseButtonDownEvent, self).processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_button_up_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_button_up_event.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+
+from .event_types import EventType
+
+__all__ = ["MouseButtonUpEvent"]
+
+
+class MouseButtonUpEvent(EventType):
+    """
+    To manage mouse up event.
+    """
+    __register_type__ = sdl2.SDL_MOUSEBUTTONUP
+    __event_method__ = "mouseEvent"
+
+    def processEvent(self, event):
+        super(MouseButtonUpEvent, self).processEvent(event)
+        self.mouse[event.button.button] = False
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_button_up_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_button_up_event.py
@@ -12,12 +12,14 @@ class MouseButtonUpEvent(EventType):
     """
     To manage mouse up event.
     """
-    __register_type__ = sdl2.SDL_MOUSEBUTTONUP
-    __event_method__ = "mouseEvent"
+    class Meta:
+        register_type = sdl2.SDL_MOUSEBUTTONUP
+        event_method = "mouseEvent"
+        event_attribute = "mouse"
 
     def processEvent(self, event):
-        super(MouseButtonUpEvent, self).processEvent(event)
         self.mouse[event.button.button] = False
+        super(MouseButtonUpEvent, self).processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_motion_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_motion_event.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+
+from .event_types import EventType
+
+__all__ = ["MouseMotionEvent"]
+
+
+class MouseMotionEvent(EventType):
+    """
+    To manage mouse motion event.
+    """
+    __register_type__ = sdl2.SDL_MOUSEMOTION
+    __event_method__ = "mouseEvent"
+
+    def processEvent(self, event):
+        super(MouseMotionEvent, self).processEvent(event)
+        self.mouse.dx = event.motion.xrel
+        self.mouse.dy = event.motion.yrel
+        self.mouse.x = event.motion.x
+        self.mouse.y = event.motion.y
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_motion_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_motion_event.py
@@ -12,15 +12,17 @@ class MouseMotionEvent(EventType):
     """
     To manage mouse motion event.
     """
-    __register_type__ = sdl2.SDL_MOUSEMOTION
-    __event_method__ = "mouseEvent"
+    class Meta:
+        register_type = sdl2.SDL_MOUSEMOTION
+        event_method = "mouseEvent"
+        event_attribute = "mouse"
 
     def processEvent(self, event):
-        super(MouseMotionEvent, self).processEvent(event)
         self.mouse.dx = event.motion.xrel
         self.mouse.dy = event.motion.yrel
         self.mouse.x = event.motion.x
         self.mouse.y = event.motion.y
+        super(MouseMotionEvent, self).processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_wheel_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_wheel_event.py
@@ -12,13 +12,15 @@ class WheelEvent(EventType):
     """
     To manage wheel event.
     """
-    __register_type__ = sdl2.SDL_MOUSEWHEEL
-    __event_method__ = "wheelEvent"
+    class Meta:
+        register_type = sdl2.SDL_MOUSEWHEEL
+        event_method = "wheelEvent"
+        event_attribute = "wheel"
 
     def processEvent(self, event):
-        super(WheelEvent, self).processEvent(event)
         self.wheel.dx = event.wheel.x
         self.wheel.dy = event.wheel.y
+        super(WheelEvent, self).processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/mouse_wheel_event.py
+++ b/LISA/gui/sdl2/event_types/mouse_wheel_event.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+
+from .event_types import EventType
+
+__all__ = ["WheelEvent"]
+
+
+class WheelEvent(EventType):
+    """
+    To manage wheel event.
+    """
+    __register_type__ = sdl2.SDL_MOUSEWHEEL
+    __event_method__ = "wheelEvent"
+
+    def processEvent(self, event):
+        super(WheelEvent, self).processEvent(event)
+        self.wheel.dx = event.wheel.x
+        self.wheel.dy = event.wheel.y
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_close_event.py
+++ b/LISA/gui/sdl2/event_types/window_close_event.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import WindowEventType
+
+__all__ = ["WindowCloseEvent"]
+
+
+class WindowCloseEvent(WindowEventType):
+    """
+    To manage window events.
+    """
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT_CLOSE
+        event_method = "closeEvent"
+        event_attribute = "window"
+
+    def processEvent(self, event):
+        self.window.id = event.window.windowID
+        self.window.end = True
+        super(WindowCloseEvent, self).processEvent(event)
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_enter_event.py
+++ b/LISA/gui/sdl2/event_types/window_enter_event.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import WindowEventType
+
+__all__ = ["WindowEnterEvent"]
+
+
+class WindowEnterEvent(WindowEventType):
+    """
+    To manage window events.
+    """
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT_ENTER
+
+    def processEvent(self, event):
+        self.window.id = event.window.windowID
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_event.py
+++ b/LISA/gui/sdl2/event_types/window_event.py
@@ -3,6 +3,7 @@
 
 import sdl2
 from .event_types import EventType
+from .event_types import WindowEventType
 
 __all__ = ["WindowEvent"]
 
@@ -11,21 +12,32 @@ class WindowEvent(EventType):
     """
     To manage window events.
     """
-    __register_type__ = sdl2.SDL_WINDOWEVENT
-    __event_method__ = "resizeEvent"
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT
+        event_method = "resizeEvent"
+        event_attribute = "window"
+
+    def __init__(self, *args, **kwargs):
+        super(WindowEvent, self).__init__(*args, **kwargs)
+
+        # create window events
+        self._createWindowEvents()
+
+    def _createWindowEvents(self):
+        """
+        Create window events type.
+        """
+        for event in WindowEventType.available_events.values():
+            event(
+                mouse=self.mouse,
+                keys=self.keys,
+                window=self.window,
+                wheel=self.wheel,
+            )
 
     def processEvent(self, event):
-        super(WindowEvent, self).processEvent(event)
-        self.window.id = event.window.windowID
-        if event.window.event == sdl2.SDL_WINDOWEVENT_CLOSE:
-            self.window.end = True
-
-        elif event.window.event == sdl2.SDL_WINDOWEVENT_RESIZED:
-            self.window.resized = True
-            self.window.windowSize = (
-                event.window.data1,
-                event.window.data2,
-            )
+        if event.window.event in WindowEventType.events:
+            WindowEventType.events[event.window.event].processEvent(event)
 
 
 # vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_event.py
+++ b/LISA/gui/sdl2/event_types/window_event.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import EventType
+
+__all__ = ["WindowEvent"]
+
+
+class WindowEvent(EventType):
+    """
+    To manage window events.
+    """
+    __register_type__ = sdl2.SDL_WINDOWEVENT
+    __event_method__ = "resizeEvent"
+
+    def processEvent(self, event):
+        super(WindowEvent, self).processEvent(event)
+        self.window.id = event.window.windowID
+        if event.window.event == sdl2.SDL_WINDOWEVENT_CLOSE:
+            self.window.end = True
+
+        elif event.window.event == sdl2.SDL_WINDOWEVENT_RESIZED:
+            self.window.resized = True
+            self.window.windowSize = (
+                event.window.data1,
+                event.window.data2,
+            )
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_focus_gained_event.py
+++ b/LISA/gui/sdl2/event_types/window_focus_gained_event.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import WindowEventType
+
+__all__ = ["WindowFocusGainedEvent"]
+
+
+class WindowFocusGainedEvent(WindowEventType):
+    """
+    To manage window events.
+    """
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT_FOCUS_GAINED
+
+    def processEvent(self, event):
+        self.window.id = event.window.windowID
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_focus_lost_event.py
+++ b/LISA/gui/sdl2/event_types/window_focus_lost_event.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import WindowEventType
+
+__all__ = ["WindowFocusLostEvent"]
+
+
+class WindowFocusLostEvent(WindowEventType):
+    """
+    To manage window events.
+    """
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT_FOCUS_LOST
+
+    def processEvent(self, event):
+        self.window.id = None
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_leave_event.py
+++ b/LISA/gui/sdl2/event_types/window_leave_event.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import WindowEventType
+
+__all__ = ["WindowLeaveEvent"]
+
+
+class WindowLeaveEvent(WindowEventType):
+    """
+    To manage window events.
+    """
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT_LEAVE
+
+    def processEvent(self, event):
+        self.window.id = None
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/event_types/window_resize_event.py
+++ b/LISA/gui/sdl2/event_types/window_resize_event.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sdl2
+from .event_types import WindowEventType
+
+__all__ = ["WindowResizeEvent"]
+
+
+class WindowResizeEvent(WindowEventType):
+    """
+    To manage window events.
+    """
+    class Meta:
+        register_type = sdl2.SDL_WINDOWEVENT_RESIZED
+        event_method = "resizeEvent"
+        event_attribute = "window"
+
+    def processEvent(self, event):
+        self.window.id = event.window.windowID
+        self.window.resized = True
+        self.window.windowSize = (
+            event.window.data1,
+            event.window.data2,
+        )
+        super(WindowResizeEvent, self).processEvent(event)
+
+
+# vim: set tw=79 :

--- a/LISA/gui/sdl2/events.py
+++ b/LISA/gui/sdl2/events.py
@@ -78,6 +78,9 @@ class Mouse(list):
     def dy(self, val):
         self._yRel = val
 
+    def reset(self):
+        self.dx, self.dy = 0., 0.
+
 
 class Window(object):
     def __init__(self):
@@ -86,45 +89,34 @@ class Window(object):
         self.windowSize = (0., 0.)
         self.id = None
 
+    def reset(self):
+        self.resized = False
+
 
 class SDLInput(object):
     def __init__(self):
-        self.mouse = Mouse()
-        self.keyboard = Keyboard()
-        self.wheel = Wheel()
-        self.window = Window()
-
         self._event = s.SDL_Event()
-        self._methods = {
-            "mouseEvent": [False, self._mouse],
-            "keyEvent": [False, self._keys],
-            "wheelEvent": [False, self._wheel],
-            "resizeEvent": [False, self._window],
-        }
 
         # create events
         self._createEvents()
 
     def _createEvents(self):
+        self.mouse = Mouse()
+        self.keyboard = Keyboard()
+        self.wheel = Wheel()
+        self.window = Window()
+
         for event in EventType.available_events.values():
             event(
                 mouse=self.mouse,
                 keys=self.keyboard,
-                methods=self._methods,
                 window=self.window,
                 wheel=self.wheel,
             )
 
     def update(self):
-        # say that we don't use any methods in the window
-        for key in self._methods.keys():
-            self._methods[key][0] = False
-        self._window.resized = False
-
-        # initiialize relative movement to null
-        self._mouse.dx, self._mouse.dy = 0., 0.
-        self._wheel.dx, self._wheel.dy = 0., 0.
-
+        self.mouse.reset()
+        self.window.reset()
         # loop over event in the queue
         while s.SDL_PollEvent(ctypes.byref(self._event)) != 0:
             if self._event.type in EventType.events:

--- a/LISA/gui/sdl2/events.py
+++ b/LISA/gui/sdl2/events.py
@@ -5,6 +5,8 @@ import sdl2 as s
 import ctypes
 import logging
 
+from .event_types import EventType
+
 __all__ = ["_SDLInput_logger", "SDLInput"]
 
 _SDLInput_logger = logging.getLogger('SDLInput')
@@ -78,33 +80,46 @@ class Mouse(list):
 
 
 class Window(object):
-    pass
+    def __init__(self):
+        self.resized = False
+        self.end = False
+        self.windowSize = (0., 0.)
+        self.id = None
 
 
 class SDLInput(object):
     def __init__(self):
-        self._mouse = Mouse()
-        self._keys = Keyboard()
-        self._wheel = Wheel()
-
-        self._end = False
+        self.mouse = Mouse()
+        self.keyboard = Keyboard()
+        self.wheel = Wheel()
+        self.window = Window()
 
         self._event = s.SDL_Event()
         self._methods = {
             "mouseEvent": [False, self._mouse],
             "keyEvent": [False, self._keys],
             "wheelEvent": [False, self._wheel],
+            "resizeEvent": [False, self._window],
         }
 
-        # window size
-        self._window_size = (0., 0.)
+        # create events
+        self._createEvents()
+
+    def _createEvents(self):
+        for event in EventType.available_events.values():
+            event(
+                mouse=self.mouse,
+                keys=self.keyboard,
+                methods=self._methods,
+                window=self.window,
+                wheel=self.wheel,
+            )
 
     def update(self):
-
         # say that we don't use any methods in the window
         for key in self._methods.keys():
             self._methods[key][0] = False
-        self._resized = False
+        self._window.resized = False
 
         # initiialize relative movement to null
         self._mouse.dx, self._mouse.dy = 0., 0.
@@ -112,73 +127,26 @@ class SDLInput(object):
 
         # loop over event in the queue
         while s.SDL_PollEvent(ctypes.byref(self._event)) != 0:
-            # set the id of the window
-            self._id = self._event.window.windowID
-
-            if self._event.type == s.SDL_WINDOWEVENT:
-                if self._event.window.event == s.SDL_WINDOWEVENT_CLOSE:
-                    self._end = True
-
-                elif self._event.window.event == s.SDL_WINDOWEVENT_RESIZED:
-                    self._resized = True
-                    self._window_size = (
-                        self._event.window.data1,
-                        self._event.window.data2,
-                    )
-
-            elif self._event.type == s.SDL_KEYDOWN:
-                self._keys[self._event.key.keysym.scancode] = True
-
-                self._methods["keyEvent"][0] = True
-
-            elif self._event.type == s.SDL_KEYUP:
-                self._keys[self._event.key.keysym.scancode] = False
-
-                self._methods["keyEvent"][0] = True
-
-            elif self._event.type == s.SDL_MOUSEBUTTONDOWN:
-                self._mouse[self._event.button.button] = True
-
-                self._methods["mouseEvent"][0] = True
-
-            elif self._event.type == s.SDL_MOUSEBUTTONUP:
-                self._mouse[self._event.button.button] = False
-
-                self._methods["mouseEvent"][0] = True
-
-            elif self._event.type == s.SDL_MOUSEMOTION:
-                self._mouse.dx = self._event.motion.xrel
-                self._mouse.dy = self._event.motion.yrel
-
-                self._methods["mouseEvent"][0] = True
-
-            elif self._event.type == s.SDL_MOUSEWHEEL:
-                self._wheel.dx = self._event.wheel.x
-                self._wheel.dy = self._event.wheel.y
-
-                self._methods["wheelEvent"][0] = True
-
+            if self._event.type in EventType.events:
+                EventType.events[self._event.type].processEvent(self._event)
             else:
                 break
-
-        self._mouse.x = self._event.motion.x
-        self._mouse.y = self._event.motion.y
-
-    @property
-    def id(self):
-        return self._id
-
-    @property
-    def End(self):
-        return self._end
 
     @property
     def keyboard(self):
         return self._keys
 
+    @keyboard.setter
+    def keyboard(self, keyboard):
+        self._keys = keyboard
+
     @property
     def mouse(self):
         return self._mouse
+
+    @mouse.setter
+    def mouse(self, mouse):
+        self._mouse = mouse
 
     @property
     def wheel(self):
@@ -187,6 +155,14 @@ class SDLInput(object):
     @wheel.setter
     def wheel(self, wheel):
         self._wheel = wheel
+
+    @property
+    def window(self):
+        return self._window
+
+    @window.setter
+    def window(self, window):
+        self._window = window
 
     def _showCursor(self, val):
         if type(val) == bool:

--- a/LISA/gui/sdl2/hook.py
+++ b/LISA/gui/sdl2/hook.py
@@ -54,9 +54,9 @@ try:
 
                 self._ev.update()
 
-                if len(self._windowList) != 0:
-                    if self._ev.id in self._windowList:
-                        self._windowList[self._ev.id].events(self._ev)
+                if len(self._windowList):
+                    if self._ev.window.id in self._windowList:
+                        self._windowList[self._ev.window.id].events(self._ev)
 
                 for win in self._windowList.values():
                     win.draw()

--- a/LISA/gui/sdl2/hook.py
+++ b/LISA/gui/sdl2/hook.py
@@ -47,6 +47,21 @@ class SDL2_Dealer(object, metaclass=EventLoopMetaclass):
     def launch_events(self):
         pass
 
+    def _dealEvents(self):
+        allow_CTRL_C()
+        while not stdin_ready():
+            start = s.SDL_GetTicks()
+
+            self._ev.update()
+
+            for win in SDLWindow.manager.windows:
+                win.draw()
+
+            stop = s.SDL_GetTicks()
+            duree = (stop - start)
+            if duree < self._framerate:
+                s.SDL_Delay(self._framerate - duree)
+
     def __del__(self):
         s.SDL_Quit()
 
@@ -69,21 +84,6 @@ try:
                 return 0
 
             self._hook.set_inputhook(events)
-
-        def _dealEvents(self):
-            allow_CTRL_C()
-            while not stdin_ready():
-                start = s.SDL_GetTicks()
-
-                self._ev.update()
-
-                for win in SDLWindow.manager.windows:
-                    win.draw()
-
-                stop = s.SDL_GetTicks()
-                duree = (stop - start)
-                if duree < self._framerate:
-                    s.SDL_Delay(self._framerate - duree)
 
 
 except:

--- a/LISA/gui/sdl2/window.py
+++ b/LISA/gui/sdl2/window.py
@@ -53,15 +53,6 @@ class SDLWindow(object):
             "Inside window %d for event.", id(self._win)
         )
 
-        if ev.End:
-            self.close()
-            return 0
-
-        # the window resized
-        if ev._resized and hasattr(self, "resizeGL"):
-            s.SDL_SetWindowSize(self._win, *ev._window_size)
-            self.resizeGL(*ev._window_size)
-
         # loop over methods and call them if the associated event occurred
         for key in ev._methods.keys():
             if ev._methods[key][0] and hasattr(self, key):
@@ -121,13 +112,13 @@ class SDLWindow(object):
     @property
     def name(self):
         return self._win_name
+
     @name.setter
     def name(self, val):
         s.SDL_SetWindowTitle(self._win, val.encode())
         self._win_name = val
 
     def close(self):
-
         # remove the window in the register of window to display in the
         # event loop
         _ipython_way_sdl2.erase(self)
@@ -168,7 +159,6 @@ class SDLWindow(object):
                     return True
 
     def wheelEvent(self, event):
-
         # loop over children widgets
         for widget in self._widget:
 
@@ -182,7 +172,12 @@ class SDLWindow(object):
                     # anymore in tis iteration
                     return True
 
-    def resizeGL(self, w, h):
-        pass
+    def resizeEvent(self, event):
+        if event.end:
+            self.close()
+            return True
+        if event.resized:
+            s.SDL_SetWindowSize(self._win, *event.windowSize)
+
 
 # vim: set tw=79 :


### PR DESCRIPTION
The idea is to not have a succession of if statement in SDLInput that we need to modify every time we need to add an event.
Instead, we define event class automatically registered at creation and instantiation with help of a metaclass defined in event_types.py.

At the class definition, it is registered in EventType.available_events and at instantiation in EventType.events. The key to retrieve the type is attribute **register_type** in the class which is the SDL event type (or something else for an other possible backend).

At creation of SDLInput, we instantiate the available defined event types. Each of them as a processEvent method with the SDL event in argument. Then it set some attributes passed at the instantiation of the event (each event is a singleton).

Then, we can call the good processing of the event by retrieving the good instance through the dictionary of event instance, since the key is the event.type. No more if statement, quick access since it is a dictionary and a good place in which to define future event type implementation (better readability and maintenance) !
